### PR TITLE
add --host_javabase argument

### DIFF
--- a/scripts/build_bazel.sh
+++ b/scripts/build_bazel.sh
@@ -33,4 +33,4 @@ fi
 
 # Build Bazel
 cd "${BAZEL_DIR}" || exit
-env EXTRA_BAZEL_ARGS="--tool_java_runtime_version=local_jdk" bash ./compile.sh
+env EXTRA_BAZEL_ARGS="--tool_java_runtime_version=local_jdk --host_javabase=@local_jdk//:jdk" bash ./compile.sh


### PR DESCRIPTION
Just tried this on a Pi 4 running a fairly up to date Buster. It required `--host_javabase=@local_jdk//:jdk` to be added to EXTRA_BAZEL_ARGS for the build to complete. This was the specific error encountered:

```
DEBUG: /tmp/bazel_oCy4rfnH/out/external/bazel_toolchains/rules/rbe_repo/checked_in.bzl:103:14: rbe_ubuntu1604_java8 not using checked in configs as detect_java_home was set to True 
ERROR: /tmp/bazel_oCy4rfnH/out/external/bazel_tools/tools/jdk/BUILD:490:6: Configurable attribute "actual" doesn't match this configuration: Could not find a JDK for host execution environment, please explicitly provide one using `--host_javabase.`
ERROR: Analysis of target '//src:bazel_nojdk' failed; build aborted: /tmp/bazel_oCy4rfnH/out/external/bazel_tools/tools/jdk/BUILD:490:6: Configurable attribute "actual" doesn't match this configuration: Could not find a JDK for host execution environment, please explicitly provide one using `--host_javabase.`
INFO: Elapsed time: 50.090s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (113 packages loaded, 1274 targets\
 configured)
```

Here's the version info of my Pi:

PRETTY_NAME="Raspbian GNU/Linux 10 (buster)"
NAME="Raspbian GNU/Linux"
VERSION_ID="10"
VERSION="10 (buster)"
VERSION_CODENAME=buster
ID=raspbian
ID_LIKE=debian
HOME_URL="http://www.raspbian.org/"
SUPPORT_URL="http://www.raspbian.org/RaspbianForums"
BUG_REPORT_URL="http://www.raspbian.org/RaspbianBugs"

Using JDK-11 via the package `openjdk-11-jdk`.

Not sure what caused the regression, but adding the PR here in case it helps.
